### PR TITLE
chore: integrate design system tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,25 +46,25 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0); /* --color-white */
-  --foreground: oklch(0.141 0.005 285.823); /* --color-zinc-950 */
-  --card: oklch(1 0 0); /* --color-white */
-  --card-foreground: oklch(0.141 0.005 285.823); /* --color-zinc-950 */
-  --popover: oklch(1 0 0); /* --color-white */
-  --popover-foreground: oklch(0.141 0.005 285.823); /* --color-zinc-950 */
-  --primary: oklch(0.21 0.006 285.885); /* --color-zinc-900 */
-  --primary-foreground: oklch(0.985 0 0); /* --color-zinc-50 */
-  --secondary: oklch(0.967 0.001 286.375); /* --color-zinc-100 */
-  --secondary-foreground: oklch(0.21 0.006 285.885); /* --color-zinc-900 */
-  --muted: oklch(0.967 0.001 286.375); /* --color-zinc-100 */
-  --muted-foreground: oklch(0.552 0.016 285.938); /* --color-zinc-500 */
-  --accent: oklch(0.967 0.001 286.375); /* --color-zinc-100 */
-  --accent-foreground: oklch(0.21 0.006 285.885); /* --color-zinc-900 */
-  --destructive: oklch(0.637 0.237 25.331); /* --color-red-500 */
-  --destructive-foreground: oklch(0.637 0.237 25.331); /* --color-red-500 */
-  --border: oklch(0.92 0.004 286.32); /* --color-zinc-200 */
-  --input: oklch(0.871 0.006 286.286); /* --color-zinc-300 */
-  --ring: oklch(0.871 0.006 286.286); /* --color-zinc-300 */
+  --background: #FFFFFF;
+  --foreground: #464646;
+  --card: #FFFFFF;
+  --card-foreground: #464646;
+  --popover: #FFFFFF;
+  --popover-foreground: #464646;
+  --primary: #00C776;
+  --primary-foreground: #FFFFFF;
+  --secondary: #2578FF;
+  --secondary-foreground: #FFFFFF;
+  --muted: #F1F1F1;
+  --muted-foreground: #656565;
+  --accent: #2578FF;
+  --accent-foreground: #FFFFFF;
+  --destructive: #FF5E37;
+  --destructive-foreground: #FFFFFF;
+  --border: #E0E0E0;
+  --input: #C5C5C5;
+  --ring: #00C776;
   --chart-1: oklch(0.646 0.222 41.116); /* --color-orange-600 */
   --chart-2: oklch(0.6 0.118 184.704); /* --color-teal-600 */
   --chart-3: oklch(0.398 0.07 227.392); /* --color-cyan-900 */
@@ -81,25 +81,25 @@
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823); /* --color-zinc-950 */
-  --foreground: oklch(0.985 0 0); /* --color-zinc-50 */
-  --card: oklch(0.141 0.005 285.823); /* --color-zinc-950 */
-  --card-foreground: oklch(0.985 0 0); /* --color-zinc-50 */
-  --popover: oklch(0.141 0.005 285.823); /* --color-zinc-950 */
-  --popover-foreground: oklch(0.985 0 0); /* --color-zinc-50 */
-  --primary: oklch(0.985 0 0); /* --color-zinc-50 */
-  --primary-foreground: oklch(0.21 0.006 285.885); /* --color-zinc-900 */
-  --secondary: oklch(0.274 0.006 286.033); /* --color-zinc-800 */
-  --secondary-foreground: oklch(0.985 0 0); /* --color-zinc-50 */
-  --muted: oklch(0.21 0.006 285.885); /* --color-zinc-900 */
-  --muted-foreground: oklch(0.65 0.01 286); /* 🔥 near --color-zinc-400 */
-  --accent: oklch(0.21 0.006 285.885); /* --color-zinc-900 */
-  --accent-foreground: oklch(0.985 0 0); /* --color-zinc-50 */
-  --destructive: oklch(0.396 0.141 25.723); /* --color-red-900 */
-  --destructive-foreground: oklch(0.637 0.237 25.331); /* --color-red-500 */
-  --border: oklch(0.274 0.006 286.033); /* --color-zinc-800 */
-  --input: oklch(0.274 0.006 286.033); /* --color-zinc-800 */
-  --ring: oklch(0.442 0.017 285.786); /* --color-zinc-600 */
+  --background: #464646;
+  --foreground: #FFFFFF;
+  --card: #464646;
+  --card-foreground: #FFFFFF;
+  --popover: #464646;
+  --popover-foreground: #FFFFFF;
+  --primary: #00C776;
+  --primary-foreground: #FFFFFF;
+  --secondary: #2578FF;
+  --secondary-foreground: #FFFFFF;
+  --muted: #545454;
+  --muted-foreground: #E0E0E0;
+  --accent: #2578FF;
+  --accent-foreground: #FFFFFF;
+  --destructive: #FF5E37;
+  --destructive-foreground: #FFFFFF;
+  --border: #545454;
+  --input: #545454;
+  --ring: #00C776;
   --chart-1: oklch(0.488 0.243 264.376); /* --color-blue-700 */
   --chart-2: oklch(0.696 0.17 162.48); /* --color-emerald-500 */
   --chart-3: oklch(0.769 0.188 70.08); /* --color-amber-500 */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next"
-import { Outfit as FontHeading, Inter as FontSans } from "next/font/google"
+import { Poppins as FontHeading, Poppins as FontSans } from "next/font/google"
 import Script from "next/script"
 
 import Footer from "@/components/footer"
@@ -12,11 +12,13 @@ import "./globals.css"
 
 const fontSans = FontSans({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-sans",
 })
 
 const fontHeading = FontHeading({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-heading",
 })
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,76 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx,mdx}",
+    "./components/**/*.{ts,tsx,mdx}",
+    "./registry/**/*.{ts,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#00C776",
+          100: "#00914C",
+          200: "#00A056",
+          300: "#00AE64",
+          400: "#00D684",
+          500: "#00E08B",
+          600: "#00F6AD",
+          700: "#E6FFF3",
+        },
+        secondary: {
+          DEFAULT: "#2578FF",
+          100: "#0F70FF",
+          200: "#4087FF",
+          300: "#5C99FF",
+          400: "#70A7FF",
+          500: "#8FBBFF",
+          600: "#C1DAFF",
+          700: "#F0F6FF",
+        },
+        alert: "#FF5E37",
+        gray: {
+          900: "#464646",
+          800: "#545454",
+          700: "#656565",
+          600: "#727272",
+          500: "#787878",
+          300: "#C5C5C5",
+          200: "#E0E0E0",
+        },
+        light: {
+          100: "#F1F1F1",
+          50: "#FAFAFA",
+          0: "#FFFFFF",
+        },
+        pink: {
+          notes: "#FF56DA",
+        },
+      },
+      fontFamily: {
+        display: ["Poppins", "sans-serif"],
+        heading: ["Poppins", "sans-serif"],
+        body: ["Poppins", "sans-serif"],
+      },
+      borderRadius: {
+        regular: "20px",
+        small: "10px",
+        pill: "1000px",
+      },
+      boxShadow: {
+        "focus-green": "0 0 0 2px rgba(0,199,118,1)",
+        "focus-gray": "0 0 0 2px rgba(114,114,114,1)",
+        fab: "1px 1px 4px rgba(0,0,0,0.2)",
+      },
+      borderWidth: {
+        "extra-thin": "0.5px",
+        thin: "1px",
+        thick: "2px",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind configuration with design tokens and utilities
- apply brand color palette and token variables to global styles
- switch layout typography to Poppins

## Testing
- `pnpm format:write`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b191a8a4b0832cb8b7e388ea130859